### PR TITLE
Update approach for fetching pairs in Agent 9

### DIFF
--- a/Impossible-Agent-Suite/LargeDepositWithdrawOnPairs/package.json
+++ b/Impossible-Agent-Suite/LargeDepositWithdrawOnPairs/package.json
@@ -17,7 +17,7 @@
     "enable": "forta-agent enable",
     "keyfile": "forta-agent keyfile",
     "format": "prettier --write \"src/**/*.ts\"",
-    "test": "jest"
+    "test": "jest --detectOpenHandles"
   },
   "dependencies": {
     "@types/lru-cache": "^5.1.1",

--- a/Impossible-Agent-Suite/LargeDepositWithdrawOnPairs/src/abi.ts
+++ b/Impossible-Agent-Suite/LargeDepositWithdrawOnPairs/src/abi.ts
@@ -1,7 +1,6 @@
 import { Interface } from "@ethersproject/abi";
 
 const FACTORY: Interface = new Interface([
-  "event PairCreated(address indexed token0, address indexed token1, address pair, uint256)",
   "function getPair(address token0, address token1) view returns (address pair)",
 ]);
 

--- a/Impossible-Agent-Suite/LargeDepositWithdrawOnPairs/src/abi.ts
+++ b/Impossible-Agent-Suite/LargeDepositWithdrawOnPairs/src/abi.ts
@@ -1,15 +1,16 @@
 import { Interface } from "@ethersproject/abi";
 
 const FACTORY: Interface = new Interface([
-  "function allPairsLength() view returns (uint256)",
-  "function allPairs(uint256 index) view returns (address)",
   "event PairCreated(address indexed token0, address indexed token1, address pair, uint256)",
+  "function getPair(address token0, address token1) view returns (address pair)",
 ]);
 
 const PAIR: Interface = new Interface([
   "event Mint(address indexed sender, uint amount0, uint amount1)",
   "event Burn(address indexed sender, uint amount0, uint amount1, address indexed to)",
   "function getReserves() view returns (uint112 reserve0, uint112 reserve1, uint32)",
+  "function token0() view returns (address token)",
+  "function token1() view returns (address token)",
 ]);
 
 export default {

--- a/Impossible-Agent-Suite/LargeDepositWithdrawOnPairs/src/agent.ts
+++ b/Impossible-Agent-Suite/LargeDepositWithdrawOnPairs/src/agent.ts
@@ -13,47 +13,29 @@ import { BigNumber } from "ethers";
 const PERCENT: number = 10; // Large percent
 const FACTORY: string = "0x918d7e714243F7d9d463C37e106235dCde294ffC";
 const FETCHER: PairFetcher = new PairFetcher(FACTORY, getEthersProvider());
-const PAIRS: Set<string> = new Set<string>();
-
-const ABI: string[] = [
-  abi.FACTORY.getEvent("PairCreated").format("full"),
-  abi.PAIR.getEvent("Mint").format("full"),
-  abi.PAIR.getEvent("Burn").format("full"),
-];
-
-const initialize = async () => {
-  const pairs: string[] = await FETCHER.getAllPairs("latest");
-  pairs.forEach((pair) => PAIRS.add(pair));
-};
 
 export const provideHandleTransaction =
-  (pairs: Set<string>, fetcher: PairFetcher, percent: number): HandleTransaction =>
-  async (txEvent: TransactionEvent): Promise<Finding[]> => {
-    const findings: Finding[] = [];
+  (fetcher: PairFetcher, percent: number): HandleTransaction =>
+    async (txEvent: TransactionEvent): Promise<Finding[]> => {
+      const findings: Finding[] = [];
 
-    const logs: LogDescription[] = txEvent.filterLog(ABI);
-    for (let log of logs) {
-      if (log.name === "PairCreated") {
-        if (log.address.toLowerCase() === fetcher.factory) {
-          pairs.add(log.args.pair.toLowerCase());
+      const logs: LogDescription[] = txEvent.filterLog(abi.PAIR.format('full'));
+      for (let log of logs) {
+        if (await fetcher.isImpossiblePair(txEvent.blockNumber, log.address.toLowerCase())) {
+          const { reserve0, reserve1 } = await fetcher.getReserves(
+            txEvent.blockNumber - 1, // reserves at the beginning of the current block
+            log.address.toLowerCase()
+          );
+          const high0: BigNumber = BigNumber.from(percent).mul(reserve0).div(100);
+          const high1: BigNumber = BigNumber.from(percent).mul(reserve1).div(100);
+          if (high0.lte(log.args.amount0) || high1.lte(log.args.amount1))
+            findings.push(createFinding(log, reserve0, reserve1));
         }
-      } else {
-        if (!pairs.has(log.address.toLowerCase())) continue;
-        const { reserve0, reserve1 } = await fetcher.getReserves(
-          txEvent.blockNumber - 1, // reserves at the beginning of the current block
-          log.address.toLowerCase()
-        );
-        const high0: BigNumber = BigNumber.from(percent).mul(reserve0).div(100);
-        const high1: BigNumber = BigNumber.from(percent).mul(reserve1).div(100);
-        if (high0.lte(log.args.amount0) || high1.lte(log.args.amount1))
-          findings.push(createFinding(log, reserve0, reserve1));
       }
-    }
 
-    return findings;
-  };
+      return findings;
+    };
 
 export default {
-  handleTransaction: provideHandleTransaction(PAIRS, FETCHER, PERCENT),
-  initialize,
+  handleTransaction: provideHandleTransaction(FETCHER, PERCENT),
 };

--- a/Impossible-Agent-Suite/LargeDepositWithdrawOnPairs/src/pairs.fetcher.spec.ts
+++ b/Impossible-Agent-Suite/LargeDepositWithdrawOnPairs/src/pairs.fetcher.spec.ts
@@ -4,7 +4,7 @@ import { createAddress } from "forta-agent-tools";
 import { BigNumber } from "ethers";
 import abi from "./abi";
 
-// pair, block, factory, token0, token1, reserve0, reserve1
+// pair, block, factory, token0, token1
 const CASES: [string, number, string, string, string][] = [
   [createAddress("0xda00"), 12, createAddress("0xfac70"), createAddress("0xabc1"), createAddress("0xdef1")],
   [createAddress("0xda01"), 13, createAddress("0xfac79"), createAddress("0xabc0"), createAddress("0xd3f1")],
@@ -34,7 +34,7 @@ describe("PairFetcher test suite", () => {
     for(let [addr, block,,,token1] of CASES){
       mockProvider
         .addCallTo(addr, block, abi.PAIR, "token1", { inputs:[], outputs:[token1]});
-      // no mock initialization for token0 so calls to token1 should return undefined
+      // no mock initialization for token0 so calls to token0 should return undefined
       expect(await fetcher.isImpossiblePair(block, addr)).toStrictEqual(false);
     }
   });


### PR DESCRIPTION
# Update approach for fetching pairs  in Agent 9

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] New Agent
- [ ] Fix an agent error
- [x] Update an agent logic/test/documentation
- [ ] Code style update (formatting, renaming)
- [ ] Other (please describe): 

## Comments
Updating approach for validating the impossible pairs.
- Previous approach: All addresses loaded into memory
- Current approach: Fetched `token0` & `token1` from pairs to validate if the pair is registered in the Factory.
