### PR TITLE
[COMP2-05] Get obfuscated files from the Docker build

### DIFF
--- a/CompoundV3-Bots/Bridge-Proposal-Integrity-Monitor/Dockerfile
+++ b/CompoundV3-Bots/Bridge-Proposal-Integrity-Monitor/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY . .
 RUN npm ci
 RUN npm run build
+RUN npm run obfuscate
 
 # Final stage: copy compiled Javascript from previous stage and install production dependencies
 FROM node:12-alpine
@@ -12,7 +13,7 @@ ENV NODE_ENV=production
 # LABEL "network.forta.settings.agent-logs.enable"="true"
 WORKDIR /app
 # COPY --from=builder /app/dist ./src
-COPY /obfuscated ./src
+COPY --from=builder /app/obfuscated ./src
 COPY package*.json ./
 COPY LICENSE.md ./
 RUN npm ci --production


### PR DESCRIPTION
# COMP2-05

## Types of changes

- [ ] New Bot
- [x] Fix a bot error
- [ ] Update a bot logic/test/documentation
- [ ] Code style update (formatting, renaming)
- [ ] Other (please describe):

## New Bot PR readiness

- [x] `npm install` command works (i.e. package-lock is updated properly)
- [x] The `name` and `description` fields of `package.json` describe the bot properly
- [x] All the libraries listed in `package.json` are being used
- [x] All the development libraries are in `devDependencies` section of `package.json`
- [x] The bot README is updated
- [x] The bot README sufficiently describes what the bot does
- [x] All the alerts that the bot emits are listed in the README
- [x] The txn/block examples listed in the README generate the expected findings
- [x] Code is easy to follow and/or properly commented
- [x] Bot contains tests
- [x] All tests pass when running `npm test`
- [x] Tests are not making real network calls (i.e. network interaction is properly mocked)
- [x] Tests cover all the paths (i.e. negative & positive test cases)
- [x] When the tests complete, no warning/errors are shown
- [x] `npm start` works without errors when executed using a jsonRpcUrl for each of the networks specified in the README
- [x] The networks specified in the README and the networks are listed in the `package.json` are the same
- [x] The code does what the README describes
- [x] Network calls are properly being cached (if duplicated calls can occur)
- [x] A performance review has been done (e.g. `Promise.all` is used whenever possible)
- [x] The findings fields are filled out correctly
- [x] Findings `protocol` is specified (if the bot is for a specific one)
- [x] `metadata` of the findings contains all the information needed.
- [x] The SDK methods are being used appropriately (e.g. `filterLog`, `filterFunction`, `getEthersProvider`)
- [x] `ABI`s match the contracts used / `args` used from `LogDescriptions` exists in the `ABI`s
- [x] The bot follows Forta recommended [best practices](https://docs.forta.network/en/latest/best-practices/)
- [x] Bot can recover from failed error calls when they can fail (e.g. errors are being caught on calls that can fail)
- [x] `repository` is added in the `package.json

## Comments

Deploying it was already successful, but it required having the obfuscated files already. This makes it so the obfuscation is done in the docker build.
