### PR TITLE
Private Key Compromise FP Update

### DIFF
--- a/private-key-compromise/README.md
+++ b/private-key-compromise/README.md
@@ -6,7 +6,7 @@ This bot identifies possible private key compromises by analyzing all the native
 
 The bot emits an alert under the following conditions:
 
-- If a receiver receives more than 3 transfers from different addresses, either native or ERC20 token (can be 4 native & 0 ERC20 token, 4 ERC20 token & 0 native, 2 native & 2 ERC20 etc.), in 6 hours, it emits an alert.
+- If a receiver receives more than 2 transfers from different addresses, either native or ERC20 token (can be 3 native & 0 ERC20 token, 3 ERC20 token & 0 native, 1 native & 2 ERC20 etc.), in 6 hours, it emits an alert.
 - The receiver address should be an EOA and should have less than 500 total transactions. (to reduce false positives because of CEX addresses)
 - in order for an ERC20 token transfer to be counted as a drain, the victim’s token balance is checked whether it’s zero for that particular token that is transferred.
 - in order for a native transfer to be counted as a drain, the bot checks the sender’s balance to see if the leftover amount is below the threshold for that particular network. These thresholds can be set inside `src/bot.config.ts`.
@@ -86,6 +86,36 @@ The bot emits an alert under the following conditions:
       - `confidence`: The confidence level of the transaction being suspicious (0-1). Always set to `0.6`
       - `remove`: Boolean indicating whether the label is removed. Always set to `false`
 
+- PKC-3
+
+  - Fired when a receiver address receives more than a certain amount of transfers over a certain amount of value in a certain time either native or ERC20 tokens.
+  - Severity is always set to "Low".
+  - Type is always set to "Suspicious".
+  - Metadata contains:
+    - `attacker`: The attacker address
+    - `victims`: The victims whose funds are transferred to the attacker
+    - `transferredAssets`: Addresses of assets that were transferred out
+    - `anomalyScore`: Score of how anomalous the alert is (0-1)
+  - Labels contain:
+    - Label 1:
+      - `entity`: The transaction's hash
+      - `entityType`: The type of the entity, always set to "Transaction"
+      - `label`: The type of the label, always set to "Suspicious"
+      - `confidence`: The confidence level of the transaction being suspicious (0-1). Always set to `0.3`
+      - `remove`: Boolean indicating whether the label is removed. Always set to `false`
+    - Label 2:
+      - `entityType`: The type of the entity, always set to "Address"
+      - `entity`: Receiver address of the funds
+      - `label`: The type of the label, always set to "Attacker"
+      - `confidence`: The confidence level of the transaction being suspicious (0-1). Always set to `0.3`
+      - `remove`: Boolean indicating whether the label is removed. Always set to `false`
+    - Label 3:
+      - `entityType`: The type of the entity, always set to "Address"
+      - `entity`: Sender addresses of the funds
+      - `label`: The type of the label, always set to "Victim"
+      - `confidence`: The confidence level of the transaction being suspicious (0-1). Always set to `0.3`
+      - `remove`: Boolean indicating whether the label is removed. Always set to `false`
+
 ## Test Data
 
 The bot behaviour can be verified with the following command:
@@ -93,5 +123,5 @@ The bot behaviour can be verified with the following command:
 On Ethereum:
 
 ```
-npm run tx 0x8f338a787398fe8925319b60e73f9ba5757a1a72b711e8d05ab081b50260ac7d,0x10136159d5991dd1ab4e444d9db0d4c750760f9ea3201e78d5697f863b9b945e,0x1ce1ca7053f5c330aa7f167f1d4580855051db05d321a1b0f730391a1ebf09d7,0x8d1f0196f996cd07e36c3ee1b0eaff8e2da0745742f1dc4dec36069d5d894a6f
+npm run tx 0x8f338a787398fe8925319b60e73f9ba5757a1a72b711e8d05ab081b50260ac7d,0x10136159d5991dd1ab4e444d9db0d4c750760f9ea3201e78d5697f863b9b945e,0x1ce1ca7053f5c330aa7f167f1d4580855051db05d321a1b0f730391a1ebf09d7
 ```

--- a/private-key-compromise/src/agent.spec.ts
+++ b/private-key-compromise/src/agent.spec.ts
@@ -122,7 +122,14 @@ class MockEthersProviderExtension extends MockEthersProvider {
   }
 }
 
-const createFinding = (txHash: string, from: string[], to: string, assets: string[], anomalyScore: number): Finding => {
+const createFinding = (
+  txHash: string,
+  from: string[],
+  to: string,
+  assets: string[],
+  anomalyScore: number,
+  alertId: string
+): Finding => {
   const victims = from.map((victim) => {
     return Label.fromObject({
       entity: victim,
@@ -136,7 +143,7 @@ const createFinding = (txHash: string, from: string[], to: string, assets: strin
   return Finding.fromObject({
     name: "Possible private key compromise",
     description: `${from.toString()} transferred funds to ${to}`,
-    alertId: "PKC-1",
+    alertId,
     severity: FindingSeverity.Low,
     type: FindingType.Suspicious,
     metadata: {
@@ -415,7 +422,7 @@ describe("Detect Private Key Compromise", () => {
       findings = await handleTransaction(txEvent3);
 
       expect(findings).toStrictEqual([
-        createFinding("0x", [senders[0], senders[1], senders[2]], receivers[1], ["ETH"], 0.1),
+        createFinding("0x", [senders[0], senders[1], senders[2]], receivers[1], ["ETH"], 0.1, "PKC-3"),
       ]);
     });
 
@@ -478,7 +485,7 @@ describe("Detect Private Key Compromise", () => {
       findings = await handleTransaction(txEvent3);
 
       expect(findings).toStrictEqual([
-        createFinding("0x", [senders[0], senders[1], senders[2]], receivers[1], [createAddress("0x99")], 0.1),
+        createFinding("0x", [senders[0], senders[1], senders[2]], receivers[1], [createAddress("0x99")], 0.1, "PKC-3"),
       ]);
 
       findings = await handleTransaction(txEvent4);
@@ -516,7 +523,14 @@ describe("Detect Private Key Compromise", () => {
       txEvent4.setValue("400");
       findings = await handleTransaction(txEvent4);
       expect(findings).toStrictEqual([
-        createFinding("0x", [senders[1], senders[2], senders[3]], receivers[2], ["ETH", createAddress("0x99")], 0.1),
+        createFinding(
+          "0x",
+          [senders[1], senders[2], senders[3]],
+          receivers[2],
+          ["ETH", createAddress("0x99")],
+          0.1,
+          "PKC-3"
+        ),
       ]);
     });
 
@@ -550,7 +564,14 @@ describe("Detect Private Key Compromise", () => {
       findings = await handleTransaction(txEvent3);
 
       expect(findings).toStrictEqual([
-        createFinding("0x", [senders[0], senders[1], senders[2]], receivers[3], ["ETH", createAddress("0x99")], 0.1),
+        createFinding(
+          "0x",
+          [senders[0], senders[1], senders[2]],
+          receivers[3],
+          ["ETH", createAddress("0x99")],
+          0.1,
+          "PKC-3"
+        ),
       ]);
 
       when(mockContractFetcher.getVictimInfo).calledWith(senders[0], 1, 1).mockResolvedValue(false);

--- a/private-key-compromise/src/agent.ts
+++ b/private-key-compromise/src/agent.ts
@@ -209,7 +209,7 @@ export const provideHandleTransaction =
               }
 
               // if there are multiple transfers to the same address, emit an alert
-              if (transferObj[to].length > 3) {
+              if (transferObj[to].length > 2) {
                 // check if the victims were initially funded by the same address
                 const hasUniqueInitialFunders = await contractFetcher.checkInitialFunder(
                   transferObj[to],
@@ -320,7 +320,7 @@ export const provideHandleTransaction =
                     }
 
                     // if there are multiple transfers to the same address, emit an alert
-                    if (transferObj[transfer.args.to].length > 3) {
+                    if (transferObj[transfer.args.to].length > 2) {
                       // check if the victims were initially funded by the same address
                       const hasUniqueInitialFunders = await contractFetcher.checkInitialFunder(
                         transferObj[transfer.args.to],

--- a/private-key-compromise/src/agent.ts
+++ b/private-key-compromise/src/agent.ts
@@ -26,9 +26,9 @@ import fetch from "node-fetch";
 
 const DATABASE_URL = "https://research.forta.network/database/bot/";
 const DATABASE_OBJECT_KEYS = {
-  transfersKey: "nm-pkComp-bot-key",
-  alertedAddressesKey: "nm-pkComp-bot-alerted-addresses-key",
-  queuedAddressesKey: "nm-pkComp-bot-queued-addresses-key",
+  transfersKey: "nm-pk-comp-bot-key",
+  alertedAddressesKey: "nm-pk-comp-bot-alerted-addresses-key",
+  queuedAddressesKey: "nm-pk-comp-bot-queued-addresses-key",
 };
 
 const BOT_ID = "0x6ec42b92a54db0e533575e4ebda287b7d8ad628b14a2268398fd4b794074ea03";

--- a/private-key-compromise/src/agent.ts
+++ b/private-key-compromise/src/agent.ts
@@ -26,9 +26,9 @@ import fetch from "node-fetch";
 
 const DATABASE_URL = "https://research.forta.network/database/bot/";
 const DATABASE_OBJECT_KEYS = {
-  transfersKey: "nm-pk-comp-bot-key",
-  alertedAddressesKey: "nm-pk-comp-bot-alerted-addresses-key",
-  queuedAddressesKey: "nm-pk-comp-bot-queued-addresses-key",
+  transfersKey: "nm-pk-comp-bot-key-1",
+  alertedAddressesKey: "nm-pk-comp-bot-alerted-addresses-key-1",
+  queuedAddressesKey: "nm-pk-comp-bot-queued-addresses-key-1",
 };
 
 const BOT_ID = "0x6ec42b92a54db0e533575e4ebda287b7d8ad628b14a2268398fd4b794074ea03";

--- a/private-key-compromise/src/balance.fetcher.spec.ts
+++ b/private-key-compromise/src/balance.fetcher.spec.ts
@@ -2,7 +2,7 @@ import { createAddress } from "forta-agent-tools";
 import { MockEthersProvider } from "forta-agent-tools/lib/test";
 import { BigNumber } from "ethers";
 import BalanceFetcher from "./balance.fetcher";
-import { BALANCEOF_ABI } from "./utils";
+import { TOKEN_ABI } from "./utils";
 import { Interface } from "ethers/lib/utils";
 
 /// [blockNumber, balance]
@@ -16,7 +16,7 @@ const TEST_BALANCES: [number, BigNumber][] = [
 
 const victimAddress = createAddress("0xa1");
 const tokenAddress = createAddress("0xa2");
-const BALANCE_IFACE = new Interface(BALANCEOF_ABI);
+const BALANCE_IFACE = new Interface(TOKEN_ABI);
 
 describe("BalanceFetcher tests suite", () => {
   const mockProvider: MockEthersProvider = new MockEthersProvider();
@@ -36,11 +36,7 @@ describe("BalanceFetcher tests suite", () => {
         inputs: [victimAddress],
         outputs: [balance],
       });
-      const fetchedBalance = await fetcher.getBalanceOf(
-        victimAddress,
-        tokenAddress,
-        block
-      );
+      const fetchedBalance = await fetcher.getBalanceOf(victimAddress, tokenAddress, block);
       expect(fetchedBalance).toStrictEqual(balance);
     }
     expect(mockProvider.call).toBeCalledTimes(5);
@@ -48,11 +44,7 @@ describe("BalanceFetcher tests suite", () => {
     // clear mockProvider to use cache
     mockProvider.clear();
     for (let [block, balance] of TEST_BALANCES) {
-      const fetchedBalance = await fetcher.getBalanceOf(
-        victimAddress,
-        tokenAddress,
-        block
-      );
+      const fetchedBalance = await fetcher.getBalanceOf(victimAddress, tokenAddress, block);
       expect(fetchedBalance).toStrictEqual(balance);
     }
     expect(mockProvider.call).toBeCalledTimes(5);

--- a/private-key-compromise/src/balance.fetcher.ts
+++ b/private-key-compromise/src/balance.fetcher.ts
@@ -1,7 +1,7 @@
 import { providers, Contract, BigNumber } from "ethers";
 import { Interface } from "ethers/lib/utils";
 import LRU from "lru-cache";
-import { BALANCEOF_ABI } from "./utils";
+import { TOKEN_ABI } from "./utils";
 
 export default class BalanceFetcher {
   readonly provider: providers.Provider;
@@ -13,14 +13,10 @@ export default class BalanceFetcher {
     this.cache = new LRU<string, Promise<BigNumber>>({
       max: 10000,
     });
-    this.tokenContract = new Contract("", new Interface(BALANCEOF_ABI), this.provider);
+    this.tokenContract = new Contract("", new Interface([TOKEN_ABI[0]]), this.provider);
   }
 
-  public async getBalanceOf(
-    victimAddress: string,
-    tokenAddress: string,
-    block: string | number
-  ): Promise<BigNumber> {
+  public async getBalanceOf(victimAddress: string, tokenAddress: string, block: string | number): Promise<BigNumber> {
     const token = this.tokenContract.attach(tokenAddress);
 
     const key: string = `${tokenAddress}-${victimAddress}-${block}`;

--- a/private-key-compromise/src/bot.config.ts
+++ b/private-key-compromise/src/bot.config.ts
@@ -5,6 +5,8 @@ export const CONTRACT_TRANSACTION_COUNT_THRESHOLD = 500;
 
 export const timePeriodDays = 0.25;
 
+export const priceThreshold = 100;
+
 // threshold amounts for individual network tokens to be left in an account in order to be considered as drained
 const thresholds = {
   MAINNET_ETH: "0.01",

--- a/private-key-compromise/src/data.fetcher.spec.ts
+++ b/private-key-compromise/src/data.fetcher.spec.ts
@@ -2,7 +2,7 @@ import { MockEthersProvider } from "forta-agent-tools/lib/test";
 import DataFetcher from "./data.fetcher";
 import { createAddress } from "forta-agent-tools";
 import { when } from "jest-when";
-import { SYMBOL_ABI } from "./utils";
+import { TOKEN_ABI } from "./utils";
 import { Interface } from "ethers/lib/utils";
 
 jest.mock("node-fetch");
@@ -16,7 +16,7 @@ const TEST_RECEIVERS: [string, string, boolean][] = [
   ["0xccc", createAddress("0xa5"), false],
 ];
 
-const SYMBOL_IFACE = new Interface(SYMBOL_ABI);
+const SYMBOL_IFACE = new Interface(TOKEN_ABI);
 
 /// [symbol, blockNumber, tokenAddress]
 const TEST_SYMBOLS: [number, string, string][] = [

--- a/private-key-compromise/src/data.fetcher.ts
+++ b/private-key-compromise/src/data.fetcher.ts
@@ -2,7 +2,7 @@ import { ethers } from "forta-agent";
 import { providers, Contract } from "ethers";
 import { Interface } from "ethers/lib/utils";
 import LRU from "lru-cache";
-import { SYMBOL_ABI } from "./utils";
+import { TOKEN_ABI } from "./utils";
 
 export default class DataFetcher {
   readonly provider: providers.Provider;
@@ -15,8 +15,8 @@ export default class DataFetcher {
     this.provider = provider;
     this.eoaCache = new LRU<string, boolean>({ max: 10000 });
     this.symbolCache = new LRU<string, string>({ max: 10000 });
-    this.tokenContractString = new Contract("", new Interface([SYMBOL_ABI[0]]), this.provider);
-    this.tokenContractBytes32 = new Contract("", new Interface([SYMBOL_ABI[1]]), this.provider);
+    this.tokenContractString = new Contract("", new Interface([TOKEN_ABI[1]]), this.provider);
+    this.tokenContractBytes32 = new Contract("", new Interface([TOKEN_ABI[2]]), this.provider);
   }
 
   isEoa = async (address: string) => {

--- a/private-key-compromise/src/findings.ts
+++ b/private-key-compromise/src/findings.ts
@@ -5,7 +5,8 @@ export const createFinding = (
   from: string[],
   to: string,
   assets: string[],
-  anomalyScore: number
+  anomalyScore: number,
+  alertId: string
 ): Finding => {
   const victims = from.map((victim) => {
     return Label.fromObject({
@@ -20,7 +21,7 @@ export const createFinding = (
   return Finding.fromObject({
     name: "Possible private key compromise",
     description: `${from.toString()} transferred funds to ${to}`,
-    alertId: "PKC-1",
+    alertId,
     severity: FindingSeverity.Low,
     type: FindingType.Suspicious,
     metadata: {

--- a/private-key-compromise/src/price.fetcher.spec.ts
+++ b/private-key-compromise/src/price.fetcher.spec.ts
@@ -1,0 +1,47 @@
+import Fetcher from "./price.fetcher";
+import { TOKEN_ABI } from "./utils";
+import { Interface } from "ethers/lib/utils";
+import { MockEthersProvider } from "forta-agent-tools/lib/test";
+import { createAddress } from "forta-agent-tools";
+import fetch from "node-fetch";
+
+jest.mock("node-fetch");
+const { Response } = jest.requireActual("node-fetch");
+
+const TEST_BLOCK = 120;
+const tokenAddress = createAddress("0xa2");
+const TOKEN_IFACE = new Interface(TOKEN_ABI);
+
+describe("TokenInfoFetcher tests suite", () => {
+  const mockProvider: MockEthersProvider = new MockEthersProvider();
+  let fetcher: Fetcher;
+
+  beforeAll(() => {
+    fetcher = new Fetcher(mockProvider as any);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should fetch the value in USD correctly", async () => {
+    const chainId = 1;
+
+    const mockFetch = jest.mocked(fetch, true);
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ ethereum: { usd: 1.2 } })));
+
+    const fetchedNativeValue = await fetcher.getValueInUsd(TEST_BLOCK, chainId, "2000000000000000000", "native");
+    expect(fetchedNativeValue).toStrictEqual(2.4);
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ "0x00000000000000000000000000000000000000a2": { usd: 3 } }))
+    );
+
+    mockProvider.addCallTo(tokenAddress, TEST_BLOCK, TOKEN_IFACE, "decimals", {
+      inputs: [],
+      outputs: [18],
+    });
+    const fetchedTokenValue = await fetcher.getValueInUsd(TEST_BLOCK, chainId, "4000000000000000000", tokenAddress);
+    expect(fetchedTokenValue).toStrictEqual(12);
+  });
+});

--- a/private-key-compromise/src/price.fetcher.ts
+++ b/private-key-compromise/src/price.fetcher.ts
@@ -1,0 +1,170 @@
+import { providers, Contract, BigNumber, ethers } from "ethers";
+import LRU from "lru-cache";
+import { Interface } from "ethers/lib/utils";
+import fetch from "node-fetch";
+import { TOKEN_ABI } from "./utils";
+
+export default class PriceFetcher {
+  provider: providers.JsonRpcProvider;
+  private cache: LRU<string, BigNumber | number | string>;
+  private tokenContract: Contract;
+  private tokensPriceCache: LRU<string, number>;
+
+  constructor(provider: ethers.providers.JsonRpcProvider) {
+    this.provider = provider;
+    this.tokenContract = new Contract("", new Interface(TOKEN_ABI), this.provider);
+    this.cache = new LRU<string, BigNumber | number | string>({
+      max: 10000,
+    });
+    this.tokensPriceCache = new LRU<string, number>({ max: 10000 });
+  }
+
+  private async getDecimals(block: number | string, tokenAddress: string): Promise<number> {
+    const token = this.tokenContract.attach(tokenAddress);
+
+    const key: string = `decimals-${tokenAddress}-${block}`;
+    if (this.cache.has(key)) return this.cache.get(key) as number;
+
+    const retryCount = 3;
+    let decimals: number = 0;
+
+    for (let i = 0; i <= retryCount; i++) {
+      try {
+        decimals = await token.decimals({
+          blockTag: block,
+        });
+        break;
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          console.log(`Error fetching decimals for token ${tokenAddress}`);
+        } else {
+          console.log(`Unknown error when fetching total supply: ${err}`);
+        }
+        if (i === retryCount) {
+          decimals = 18;
+          console.log(`Failed to fetch decimals for ${tokenAddress} after retries, using default max value: 18`);
+          break;
+        }
+
+        console.log(`Retrying in 1 second...`);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+
+    this.cache.set(key, decimals);
+
+    return decimals;
+  }
+
+  private getTokenPriceUrl = (chain: string, token: string) => {
+    return `https://api.coingecko.com/api/v3/simple/token_price/${chain}?contract_addresses=${token}&vs_currencies=usd`;
+  };
+
+  private getChainByChainId = (chainId: number) => {
+    switch (Number(chainId)) {
+      case 10:
+        return "optimistic-ethereum";
+      case 56:
+        return "binance-smart-chain";
+      case 137:
+        return "polygon-pos";
+      case 250:
+        return "fantom";
+      case 42161:
+        return "arbitrum-one";
+      case 43114:
+        return "avalanche";
+      default:
+        return "ethereum";
+    }
+  };
+
+  private getNativeTokenByChainId = (chainId: number) => {
+    switch (Number(chainId)) {
+      case 10:
+        return "ethereum";
+      case 56:
+        return "binancecoin";
+      case 137:
+        return "matic-network";
+      case 250:
+        return "fantom";
+      case 42161:
+        return "ethereum";
+      case 43114:
+        return "avalanche-2";
+      default:
+        return "ethereum";
+    }
+  };
+
+  private getNativeTokenPrice = (chain: string) => {
+    return `https://api.coingecko.com/api/v3/simple/price?ids=${chain}&vs_currencies=usd`;
+  };
+
+  public async getValueInUsd(block: number, chainId: number, amount: string, token: string): Promise<number> {
+    let response, usdPrice;
+    let foundInCache = false;
+
+    for (let i = block - 9; i <= block; i++) {
+      const key = `usdPrice-${token}-${i}`;
+      if (this.tokensPriceCache.has(key)) {
+        usdPrice = this.tokensPriceCache.get(key);
+        foundInCache = true;
+        break;
+      }
+    }
+
+    if (!foundInCache) {
+      if (token === "native") {
+        const chain = this.getNativeTokenByChainId(chainId);
+
+        let retries = 3;
+        while (retries > 0) {
+          try {
+            response = (await (await fetch(this.getNativeTokenPrice(chain))).json()) as any;
+            break;
+          } catch {
+            retries--;
+          }
+        }
+        if (!response || !response[chain]) {
+          return 0;
+        } else {
+          usdPrice = response[chain].usd;
+        }
+      } else {
+        const chain = this.getChainByChainId(chainId);
+        let retryCount = 1;
+        for (let i = 0; i < retryCount; i++) {
+          try {
+            response = (await (await fetch(this.getTokenPriceUrl(chain, token))).json()) as any;
+            if (response && response[token]) {
+              usdPrice = response[token].usd;
+              break;
+            } else {
+              throw new Error("Error: Can't fetch USD price on CoinGecko");
+            }
+          } catch {
+            if (!response) {
+              await new Promise((resolve) => setTimeout(resolve, 1000));
+            } else {
+              break;
+            }
+          }
+        }
+      }
+
+      this.tokensPriceCache.set(`usdPrice-${token}-${block}`, usdPrice);
+    }
+
+    let tokenAmount;
+    if (token === "native") {
+      tokenAmount = ethers.utils.formatEther(amount);
+    } else {
+      const decimals = await this.getDecimals(block, token);
+      tokenAmount = ethers.utils.formatUnits(amount, decimals);
+    }
+    return Number(tokenAmount) * usdPrice;
+  }
+}

--- a/private-key-compromise/src/utils.ts
+++ b/private-key-compromise/src/utils.ts
@@ -38,10 +38,13 @@ export type QueuedAddress = {
 
 export const ERC20_TRANSFER_FUNCTION = "function transfer(address to, uint256 amount) public";
 
-export const BALANCEOF_ABI = ["function balanceOf(address account) external view returns (uint256)"];
-export const SYMBOL_ABI = [
+export const TOKEN_ABI = [
+  "function balanceOf(address account) external view returns (uint256)",
   "function symbol() external view returns (string)",
   "function symbol() external view returns (bytes32)",
+  "function name() public view returns (string)",
+  "function decimals() external view returns (uint8)",
+  "function totalSupply() external view returns (uint256)",
 ];
 
 export const updateRecord = async (from: string, to: string, asset: string, hash: string, transferObj: Transfer) => {

--- a/private-key-compromise/src/utils.ts
+++ b/private-key-compromise/src/utils.ts
@@ -17,6 +17,7 @@ export type Transfer = Record<
   {
     victimAddress: string;
     transferredAsset: string;
+    valueInUSD: number;
     txHash: string;
   }[]
 >;
@@ -47,25 +48,50 @@ export const TOKEN_ABI = [
   "function totalSupply() external view returns (uint256)",
 ];
 
-export const updateRecord = async (from: string, to: string, asset: string, hash: string, transferObj: Transfer) => {
+export const updateRecord = async (
+  from: string,
+  to: string,
+  asset: string,
+  hash: string,
+  price: number,
+  transferObj: Transfer
+) => {
   /**
    * Logic is to persist data into transferObj as shown below
    *
    *  {
-   *    attacker1: [victim1, victim2..]
-   *    attacker2: [victim1, victim2, victim3..]
+   *    attacker1: [{
+   *                  victimAddress:   victim1
+   *                  transferredAsset: asset1
+   *                },
+   *                {
+   *                  victimAddress:   victim2
+   *                  transferredAsset: asset2
+   *                }]
+   *    attacker2: [{
+   *                  victimAddress:   victim1
+   *                  transferredAsset: asset1
+   *                },
+   *                {
+   *                  victimAddress:   victim2
+   *                  transferredAsset: asset2
+   *                },
+   *                {
+   *                  victimAddress:   victim3
+   *                  transferredAsset: asset3
+   *                }]
    *    ...
    *  }
    */
 
   // if the attacker is already in transferObj and the victim is not, push the new victim address
   if (transferObj[to] && !transferObj[to].some((el) => el.victimAddress == from)) {
-    transferObj[to].push({ victimAddress: from, transferredAsset: asset, txHash: hash });
+    transferObj[to].push({ victimAddress: from, transferredAsset: asset, valueInUSD: price, txHash: hash });
   }
 
   // if the attacker is not in db, append it
   else if (!transferObj[to]) {
-    transferObj[to] = [{ victimAddress: from, transferredAsset: asset, txHash: hash }];
+    transferObj[to] = [{ victimAddress: from, transferredAsset: asset, valueInUSD: price, txHash: hash }];
   }
 };
 


### PR DESCRIPTION
Private Key Compromise FP Update

- [ ] New Bot
- [ ] Fix a bot error
- [x] Update a bot logic/test/documentation
- [ ] Code style update (formatting, renaming)
- [ ] Other (please describe):

To get rid of dust token transfers, added a logic for when a receiver address receives more than a certain amount of transfers over a certain amount of value in a certain time. Created a new alert type(PKC-3)