### PR TITLE
Fix typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Forta Agents proof of concepts from **Venice** team.
 - **Multi Gas Threshold**: Detect unusual amount of gas used.
 - **Anomalous Tx Value**: Detect transactions using very high tx value.
 - **High volume of failed transactions**: Detect protocols receiving a high volume of failed transactions.
-- **Onwership Transfer**: Detect OwnershipTrasnferred events.
+- **Ownership Transfer**: Detect OwnershipTrasnferred events.
 - **Flash Loan**: Detects use of flash loan.
 - **TimeLock**: Detects use of Openzeppelin Timelock.
 - **Detect Upgrade Events**: The agent detects upgrade events either for a specific contract or for any


### PR DESCRIPTION
### Summary
Fixes a typo in the `README.md` file.

### Changes
- Corrected "OwnershipTrasnferred" to "OwnershipTransferred" in the description of ownership transfer detection.
7